### PR TITLE
chore: allow for wider range of spl-token versions

### DIFF
--- a/cvlr-solana/Cargo.toml
+++ b/cvlr-solana/Cargo.toml
@@ -17,9 +17,9 @@ default = []
 rt = ["cvlr-nondet/rt", "cvlr-asserts/rt", "cvlr-mathint/rt"]
 
 [dependencies]
-solana-program = ">=1.18, <2"
-spl-token = { version = "4.0.3" }
-spl-token-2022 = { version = "3" }
+solana-program = ">=1.18, <2.2"
+spl-token = ">=4.0.3, <8"
+spl-token-2022 = ">=3.0.5, <8"
 arrayref = "0.3"
 
 cvlr-asserts = { workspace = true }


### PR DESCRIPTION
We provide summaries for both spl-token and spl-token-2022. The two versions have to match so that they use same solana-program version.