### PR TITLE
fix: no-entrypoint for dependencies

### DIFF
--- a/cvlr-solana/Cargo.toml
+++ b/cvlr-solana/Cargo.toml
@@ -17,9 +17,9 @@ default = []
 rt = ["cvlr-nondet/rt", "cvlr-asserts/rt", "cvlr-mathint/rt"]
 
 [dependencies]
-solana-program = ">=1.18, <2.2"
-spl-token = ">=4.0.3, <8"
-spl-token-2022 = ">=3.0.5, <8"
+solana-program = ">=1.18"
+spl-token = { version = ">=4.0.0, <8", features = ["no-entrypoint"] }
+spl-token-2022 = { version = ">=3.0.5, <8", features = ["no-entrypoint"] }
 arrayref = "0.3"
 
 cvlr-asserts = { workspace = true }


### PR DESCRIPTION
Right now, cvlr-solana depends on spl-token and spl-token-2022 These are full programs, so we must pass no-entrypoint feature to them.

Usually this is done by the client of cvlr-solana, but not every client needs these programs as well.